### PR TITLE
Adapting different SQL generation behavior of different activerecord versions

### DIFF
--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -71,7 +71,7 @@ module ClosureTree
       if order_option?
         scope.order(*([additional_order_by, order_by].compact))
       else
-        additional_order_by ? scope.order(additional_order_by) : scope
+        additional_order_by ? scope.reorder(additional_order_by) : scope
       end
     end
 

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -69,7 +69,7 @@ module ClosureTree
 
     def scope_with_order(scope, additional_order_by = nil)
       if order_option?
-        scope.order(*([additional_order_by, order_by].compact))
+        scope.reorder(*([additional_order_by, order_by].compact))
       else
         additional_order_by ? scope.reorder(additional_order_by) : scope
       end


### PR DESCRIPTION
Use `scope.reorder` instead of `scope.order` to adapting different SQL
generation behavior of different `activerecord` version.

In `hash_tree.rb` file:

```
  def build_hash_tree(tree_scope)
    p tree_scope.to_sql
    tree = ActiveSupport::OrderedHash.new
    id_to_hash = {}

    tree_scope.each do |ea|
      h = id_to_hash[ea.id] = ActiveSupport::OrderedHash.new
      if ea.root? || tree.empty? # We're at the top of the tree.
        tree[ea] = h
      else
        id_to_hash[ea._ct_parent_id][ea] = h
      end
    end
    tree
  end
```

For `activerecord` version old than `4.0.3`,  `tree_scope.to_sql` generates SQL like 

```
.. ON "collections".id = generation_depth.descendant_id ORDER BY generation_depth.depth, priority, priority DESC
```

, which works fine.

But `activerecord` version `4.0.3`, it generates SQL like

```
ON "collections".id = generation_depth.descendant_id ORDER BY priority DESC, generation_depth.depth, priority
```

, which would not work with my categories table.
