### PR TITLE
Feature/primary keys

### DIFF
--- a/lib/closure_tree/acts_as_tree.rb
+++ b/lib/closure_tree/acts_as_tree.rb
@@ -12,6 +12,7 @@ module ClosureTree
         :name_column,
         :order,
         :parent_column_name,
+        :primary_key,
         :with_advisory_lock,
         :touch
       )

--- a/lib/closure_tree/digraphs.rb
+++ b/lib/closure_tree/digraphs.rb
@@ -14,7 +14,7 @@ module ClosureTree
     module ClassMethods
       # Renders the given scope as a DOT digraph, suitable for rendering by Graphviz
       def to_dot_digraph(tree_scope)
-        id_to_instance = tree_scope.reduce({}) { |h, ea| h[ea.id] = ea; h }
+        id_to_instance = tree_scope.reduce({}) { |h, ea| h[ea._ct_id] = ea; h }
         output = StringIO.new
         output << "digraph G {\n"
         tree_scope.each do |ea|

--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -5,7 +5,7 @@ module ClosureTree
     # Find a child node whose +ancestry_path+ minus self.ancestry_path is +path+.
     def find_by_path(path, attributes = {})
       return self if path.empty?
-      self.class.find_by_path(path, attributes, id)
+      self.class.find_by_path(path, attributes, send(_ct.primary_key))
     end
 
     # Find a child node whose +ancestry_path+ minus self.ancestry_path is +path+
@@ -38,7 +38,7 @@ module ClosureTree
         INNER JOIN (
           SELECT descendant_id
           FROM #{_ct.quoted_hierarchy_table_name}
-          WHERE ancestor_id = #{_ct.quote(self.id)}
+          WHERE ancestor_id = #{_ct.quote(self.send _ct.primary_key)}
           GROUP BY 1
           HAVING MAX(#{_ct.quoted_hierarchy_table_name}.generations) = #{generation_level.to_i}
         ) AS descendants ON (#{_ct.quoted_table_name}.#{_ct.primary_key} = descendants.descendant_id)

--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -61,7 +61,7 @@ module ClosureTree
         if instance.new_record?
           all
         else
-          where(["#{_ct.quoted_table_name}.#{_ct.quoted_id_column_name} != ?", instance.id])
+          where(["#{_ct.quoted_table_name}.#{_ct.quoted_id_column_name} != ?", instance._ct_id])
         end
       end
 

--- a/lib/closure_tree/hash_tree.rb
+++ b/lib/closure_tree/hash_tree.rb
@@ -34,7 +34,7 @@ module ClosureTree
             GROUP BY descendant_id
             #{having_clause}
           ) AS generation_depth
-            ON #{_ct.quoted_table_name}.#{primary_key} = generation_depth.descendant_id
+            ON #{_ct.quoted_table_name}.#{_ct.primary_key} = generation_depth.descendant_id
         SQL
         _ct.scope_with_order(joins(generation_depth), "generation_depth.depth")
       end

--- a/lib/closure_tree/hash_tree.rb
+++ b/lib/closure_tree/hash_tree.rb
@@ -45,7 +45,7 @@ module ClosureTree
         id_to_hash = {}
 
         tree_scope.each do |ea|
-          h = id_to_hash[ea.id] = ActiveSupport::OrderedHash.new
+          h = id_to_hash[ea._ct_id] = ActiveSupport::OrderedHash.new
           if ea.root? || tree.empty? # We're at the top of the tree.
             tree[ea] = h
           else

--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -101,9 +101,9 @@ module ClosureTree
             SELECT DISTINCT descendant_id
             FROM (SELECT descendant_id
               FROM #{_ct.quoted_hierarchy_table_name}
-              WHERE ancestor_id = #{_ct.quote(id)}
+              WHERE ancestor_id = #{_ct.quote(_ct_id)}
             ) AS x )
-            OR descendant_id = #{_ct.quote(id)}
+            OR descendant_id = #{_ct.quote(_ct_id)}
         SQL
       end
     end

--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -62,7 +62,11 @@ module ClosureTree
     def rebuild!(called_by_rebuild = false)
       _ct.with_advisory_lock do
         delete_hierarchy_references unless @was_new_record
-        hierarchy_class.create!(:ancestor => self, :descendant => self, :generations => 0)
+        hierarchy_class.create!(
+          :ancestor_id => self.send(_ct.primary_key),
+          :descendant_id => self.send(_ct.primary_key),
+          :generations => 0
+        )
         unless root?
           _ct.connection.execute <<-SQL.strip_heredoc
             INSERT INTO #{_ct.quoted_hierarchy_table_name}

--- a/lib/closure_tree/model.rb
+++ b/lib/closure_tree/model.rb
@@ -27,6 +27,7 @@ module ClosureTree
       has_many :ancestor_hierarchies, *_ct.has_many_without_order_option(
         class_name: _ct.hierarchy_class_name,
         foreign_key: 'descendant_id',
+        primary_key: _ct.primary_key,
         order: order_by_generations)
 
       has_many :self_and_ancestors, *_ct.has_many_without_order_option(
@@ -37,6 +38,7 @@ module ClosureTree
       has_many :descendant_hierarchies, *_ct.has_many_without_order_option(
         class_name: _ct.hierarchy_class_name,
         foreign_key: 'ancestor_id',
+        primary_key: _ct.primary_key,
         order: order_by_generations)
 
       has_many :self_and_descendants, *_ct.has_many_with_order_option(
@@ -145,7 +147,7 @@ module ClosureTree
     end
 
     def _ct_id
-      read_attribute(_ct.model_class.primary_key)
+      read_attribute(_ct.primary_key)
     end
 
     def _ct_quoted_id

--- a/lib/closure_tree/model.rb
+++ b/lib/closure_tree/model.rb
@@ -8,6 +8,7 @@ module ClosureTree
       belongs_to :parent,
                  class_name: _ct.model_class.to_s,
                  foreign_key: _ct.parent_column_name,
+                 primary_key: _ct.primary_key,
                  inverse_of: :children,
                  touch: _ct.options[:touch]
 
@@ -19,6 +20,7 @@ module ClosureTree
       has_many :children, *_ct.has_many_with_order_option(
         class_name: _ct.model_class.to_s,
         foreign_key: _ct.parent_column_name,
+        primary_key: _ct.primary_key,
         dependent: _ct.options[:dependent],
         inverse_of: :parent)
 

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -15,6 +15,7 @@ module ClosureTree
       @options = {
         :base_class => model_class,
         :parent_column_name => 'parent_id',
+        :primary_key => :id,
         :dependent => :nullify, # or :destroy or :delete_all -- see the README
         :name_column => 'name',
         :with_advisory_lock => true

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -15,7 +15,7 @@ module ClosureTree
       @options = {
         :base_class => model_class,
         :parent_column_name => 'parent_id',
-        :primary_key => :id,
+        :primary_key => nil,
         :dependent => :nullify, # or :destroy or :delete_all -- see the README
         :name_column => 'name',
         :with_advisory_lock => true

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -104,7 +104,7 @@ module ClosureTree
     end
 
     def ids_from(scope)
-      scope.pluck(model_class.primary_key)
+      scope.pluck(primary_key)
     end
 
     def where_eq(column_name, value)

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -32,8 +32,8 @@ module ClosureTree
       include_forbidden_attributes_protection = include_forbidden_attributes_protection?
       hierarchy_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
         include ActiveModel::ForbiddenAttributesProtection if include_forbidden_attributes_protection
-        belongs_to :ancestor, :class_name => "#{model_class}"
-        belongs_to :descendant, :class_name => "#{model_class}"
+        belongs_to :ancestor, :class_name => "#{model_class}", :primary_key => :"#{primary_key}"
+        belongs_to :descendant, :class_name => "#{model_class}", :primary_key => :"#{primary_key}"
         attr_accessible :ancestor, :descendant, :generations if use_attr_accessible
         def ==(other)
           self.class == other.class && ancestor_id == other.ancestor_id && descendant_id == other.descendant_id

--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -30,6 +30,10 @@ module ClosureTree
       options[:parent_column_name]
     end
 
+    def primary_key
+      options[:primary_key]
+    end
+
     def parent_column_sym
       parent_column_name.to_sym
     end

--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -31,7 +31,7 @@ module ClosureTree
     end
 
     def primary_key
-      options[:primary_key]
+      options[:primary_key] || model_class.primary_key
     end
 
     def parent_column_sym
@@ -62,7 +62,7 @@ module ClosureTree
     end
 
     def quoted_id_column_name
-      connection.quote_column_name model_class.primary_key
+      connection.quote_column_name primary_key
     end
 
     def quoted_parent_column_name

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -36,6 +36,26 @@ class UUIDTag < ActiveRecord::Base
   end
 end
 
+class PrimaryKeyTag < ActiveRecord::Base
+  before_create :set_uuid
+  acts_as_tree :dependent => :destroy, :order => 'name', :primary_key => :uuid
+  before_destroy :add_destroyed_tag
+  attr_accessible :name, :title if _ct.use_attr_accessible?
+
+  def set_uuid
+    self.uuid = UUIDTools::UUID.timestamp_create.to_s
+  end
+
+  def to_s
+    name
+  end
+
+  def add_destroyed_tag
+    # Proof for the tests that the destroy rather than the delete method was called:
+    DestroyedTag.create(:name => name)
+  end
+end
+
 class DestroyedTag < ActiveRecord::Base
   attr_accessible :name if Tag._ct.use_attr_accessible?
 end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -38,6 +38,23 @@ ActiveRecord::Schema.define(:version => 0) do
     t.integer "generations", :null => false
   end
 
+
+  create_table "primary_key_tags" do |t|
+    t.string "uuid", :unique => true
+    t.string "name"
+    t.string "title"
+    t.string "parent_id"
+    t.integer "sort_order"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "primary_key_tag_hierarchies", :id => false do |t|
+    t.string "ancestor_id", :null => false
+    t.string "descendant_id", :null => false
+    t.integer "generations", :null => false
+  end
+
   create_table "destroyed_tags" do |t|
     t.string "name"
   end

--- a/spec/primary_key_tag_spec.rb
+++ b/spec/primary_key_tag_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require 'tag_examples'
+
+describe PrimaryKeyTag do
+  it_behaves_like Tag
+end

--- a/spec/tag_examples.rb
+++ b/spec/tag_examples.rb
@@ -237,6 +237,7 @@ shared_examples_for Tag do
       grandparent = tag_class.create(:name => 'Grandparent')
       parent = grandparent.children.create(:name => 'Parent')
       child1 = tag_class.create(:name => 'First Child', :parent => parent)
+      puts child1.parent_id
       child2 = tag_class.new(:name => 'Second Child')
       parent.children << child2
       child3 = tag_class.new(:name => 'Third Child')

--- a/spec/tag_examples.rb
+++ b/spec/tag_examples.rb
@@ -104,7 +104,7 @@ shared_examples_for Tag do
         tag_class.leaves.should == [@leaf]
       end
       it "should return child_ids for root" do
-        @root.child_ids.should == [@leaf.id]
+        @root.child_ids.should == [@leaf._ct_id]
       end
 
       it "should return an empty array for leaves" do
@@ -208,19 +208,19 @@ shared_examples_for Tag do
 
       it "cleans up hierarchy references for leaves" do
         @leaf.destroy
-        tag_hierarchy_class.where(:ancestor_id => @leaf.id).should be_empty
-        tag_hierarchy_class.where(:descendant_id => @leaf.id).should be_empty
+        tag_hierarchy_class.where(:ancestor_id => @leaf._ct_id).should be_empty
+        tag_hierarchy_class.where(:descendant_id => @leaf._ct_id).should be_empty
       end
 
       it "cleans up hierarchy references" do
         @mid.destroy
-        tag_hierarchy_class.where(:ancestor_id => @mid.id).should be_empty
-        tag_hierarchy_class.where(:descendant_id => @mid.id).should be_empty
+        tag_hierarchy_class.where(:ancestor_id => @mid._ct_id).should be_empty
+        tag_hierarchy_class.where(:descendant_id => @mid._ct_id).should be_empty
         @root.reload.should be_root
         root_hiers = @root.ancestor_hierarchies.to_a
         root_hiers.size.should == 1
-        tag_hierarchy_class.where(:ancestor_id => @root.id).should == root_hiers
-        tag_hierarchy_class.where(:descendant_id => @root.id).should == root_hiers
+        tag_hierarchy_class.where(:ancestor_id => @root._ct_id).should == root_hiers
+        tag_hierarchy_class.where(:descendant_id => @root._ct_id).should == root_hiers
       end
 
       it "should have different hash codes for each hierarchy model" do
@@ -237,7 +237,6 @@ shared_examples_for Tag do
       grandparent = tag_class.create(:name => 'Grandparent')
       parent = grandparent.children.create(:name => 'Parent')
       child1 = tag_class.create(:name => 'First Child', :parent => parent)
-      puts child1.parent_id
       child2 = tag_class.new(:name => 'Second Child')
       parent.children << child2
       child3 = tag_class.new(:name => 'Third Child')
@@ -569,7 +568,7 @@ shared_examples_for Tag do
         tag_class.find_or_create_by_path(%w(a b1 c1))
         tag_class.find_or_create_by_path(%w(a b2 c2))
         tag_class.find_or_create_by_path(%w(a b2 c3))
-        a, b1, b2, c1, c2, c3 = %w(a b1 b2 c1 c2 c3).map { |ea| tag_class.where(:name => ea).first.id }
+        a, b1, b2, c1, c2, c3 = %w(a b1 b2 c1 c2 c3).map { |ea| tag_class.where(:name => ea).first._ct_id }
         dot = tag_class.roots.first.to_dot_digraph
         dot.should == <<-DOT
 digraph G {


### PR DESCRIPTION
Adding a `:primary_key` option to closure tree. This allows closure tree to reference models in the tree by a different column then their default primary key.

Useful when dealing with models which have both and id and a uuid and the closure tree needs to be built off the uuids.
