### PR TITLE
Specify null false for timestamps and pass id to exists?

### DIFF
--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -7,8 +7,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.string "title"
     t.integer "parent_id"
     t.integer "sort_order"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.timestamps null: false
   end
 
   add_foreign_key(:tags, :tags, :column => 'parent_id')
@@ -28,8 +27,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.string "title"
     t.string "parent_uuid"
     t.integer "sort_order"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.timestamps null: false
   end
 
   create_table "uuid_tag_hierarchies", :id => false do |t|
@@ -48,8 +46,7 @@ ActiveRecord::Schema.define(:version => 0) do
   create_table "users" do |t|
     t.string "email"
     t.integer "referrer_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.timestamps null: false
   end
 
   add_foreign_key(:users, :users, :column => 'referrer_id')
@@ -129,7 +126,7 @@ ActiveRecord::Schema.define(:version => 0) do
   create_table 'menu_items' do |t|
     t.string 'name'
     t.integer 'parent_id'
-    t.timestamps
+    t.timestamps null: false
   end
 
   add_foreign_key(:menu_items, :menu_items, :column => 'parent_id')

--- a/spec/generators/migration_generator_spec.rb
+++ b/spec/generators/migration_generator_spec.rb
@@ -1,3 +1,4 @@
+require 'rspec/rails'
 require 'spec_helper'
 require 'ammeter/init'
 

--- a/spec/label_spec.rb
+++ b/spec/label_spec.rb
@@ -56,9 +56,9 @@ describe Label do
       b = a.add_child Label.new(name: 'b')
       c = b.add_child Label.new(name: 'c')
       a.destroy
-      expect(Label.exists?(a)).to be_falsey
-      expect(Label.exists?(b)).to be_falsey
-      expect(Label.exists?(c)).to be_falsey
+      expect(Label.exists?(a.id)).to be_falsey
+      expect(Label.exists?(b.id)).to be_falsey
+      expect(Label.exists?(c.id)).to be_falsey
     end
 
     it "properly destroys descendents created with <<" do
@@ -68,9 +68,9 @@ describe Label do
       c = Label.new(name: 'c')
       b.children << c
       a.destroy
-      expect(Label.exists?(a)).to be_falsey
-      expect(Label.exists?(b)).to be_falsey
-      expect(Label.exists?(c)).to be_falsey
+      expect(Label.exists?(a.id)).to be_falsey
+      expect(Label.exists?(b.id)).to be_falsey
+      expect(Label.exists?(c.id)).to be_falsey
     end
   end
 


### PR DESCRIPTION
Fix Rails 5 deprecation warning for not explicitly setting the null option
for timestamps. Also moved other timestamps to use timestamps method.

This PR also changes passing id into `exists?`

This deprecation warning was introduced in https://github.com/rails/rails/pull/16481