### PR TITLE
fix uuids for graphviz

### DIFF
--- a/lib/closure_tree/digraphs.rb
+++ b/lib/closure_tree/digraphs.rb
@@ -19,9 +19,9 @@ module ClosureTree
         output << "digraph G {\n"
         tree_scope.each do |ea|
           if id_to_instance.key? ea._ct_parent_id
-            output << "  #{ea._ct_parent_id} -> #{ea._ct_id}\n"
+            output << "  \"#{ea._ct_parent_id}\" -> \"#{ea._ct_id}\"\n"
           end
-          output << "  #{ea._ct_id} [label=\"#{ea.to_digraph_label}\"]\n"
+          output << "  \"#{ea._ct_id}\" [label=\"#{ea.to_digraph_label}\"]\n"
         end
         output << "}\n"
         output.string

--- a/spec/tag_examples.rb
+++ b/spec/tag_examples.rb
@@ -610,17 +610,17 @@ shared_examples_for Tag do
         dot = tag_class.roots.first.to_dot_digraph
         expect(dot).to eq <<-DOT
 digraph G {
-  #{a} [label="a"]
-  #{a} -> #{b1}
-  #{b1} [label="b1"]
-  #{a} -> #{b2}
-  #{b2} [label="b2"]
-  #{b1} -> #{c1}
-  #{c1} [label="c1"]
-  #{b2} -> #{c2}
-  #{c2} [label="c2"]
-  #{b2} -> #{c3}
-  #{c3} [label="c3"]
+  "#{a}" [label="a"]
+  "#{a}" -> "#{b1}"
+  "#{b1}" [label="b1"]
+  "#{a}" -> "#{b2}"
+  "#{b2}" [label="b2"]
+  "#{b1}" -> "#{c1}"
+  "#{c1}" [label="c1"]
+  "#{b2}" -> "#{c2}"
+  "#{c2}" [label="c2"]
+  "#{b2}" -> "#{c3}"
+  "#{c3}" [label="c3"]
 }
         DOT
       end


### PR DESCRIPTION
Fix issues with UUID and the `.dot` files.

I kept getting errors like this:
```
Warning: syntax ambiguity - badly delimited number '-16289e' in line 17 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '-2e' in line 18 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '-4a' in line 18 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '-16289e' in line 18 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '43c' in line 19 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '-20c' in line 19 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '-42e' in line 19 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '-694e' in line 19 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '-4a' in line 19 of example.dot splits into two tokens
Warning: syntax ambiguity - badly delimited number '-4a' in line 20 of example.dot splits into two tokens
```

I just quoted IDs in the `.dot` files. cc @seuros 