### PR TITLE
Improve performance issue for DELETE command

### DIFF
--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -98,8 +98,8 @@ module ClosureTree
             FROM (SELECT descendant_id
               FROM #{_ct.quoted_hierarchy_table_name}
               WHERE ancestor_id = #{_ct.quote(id)}
+                 OR descendant_id = #{_ct.quote(id)}
             ) AS x )
-            OR descendant_id = #{_ct.quote(id)}
         SQL
       end
     end


### PR DESCRIPTION
# Before
```
                                                                                    QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on log_hierarchies  (cost=4403.03..6923802.33 rows=169553156 width=6) (actual time=52728.567..52728.567 rows=0 loops=1)
   ->  Seq Scan on log_hierarchies  (cost=4403.03..6923802.33 rows=169553156 width=6) (actual time=52728.564..52728.564 rows=0 loops=1)
         Filter: ((hashed SubPlan 1) OR (descendant_id = 1022566))
         Rows Removed by Filter: 338996939
         SubPlan 1
           ->  Unique  (cost=0.57..4403.03 rows=1 width=4) (actual time=0.085..0.085 rows=0 loops=1)
                 ->  Index Only Scan using log_anc_desc_idx on log_hierarchies log_hierarchies_1  (cost=0.57..4396.98 rows=2420 width=4) (actual time=0.085..0.085 rows=0 loops=1)
                       Index Cond: (ancestor_id = 1022566)
                       Heap Fetches: 0
 Planning time: 0.223 ms
 Execution time: 52728.657 ms
(11 rows)
```

# After
```
                                                                                       QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on log_hierarchies  (cost=1.15..5006.48 rows=11962 width=34) (actual time=11.178..11.178 rows=0 loops=1)
   ->  Nested Loop  (cost=1.15..5006.48 rows=11962 width=34) (actual time=0.126..10.466 rows=561 loops=1)
         ->  Subquery Scan on "ANY_subquery"  (cost=0.57..4403.04 rows=1 width=32) (actual time=0.077..0.172 rows=33 loops=1)
               ->  Unique  (cost=0.57..4403.03 rows=1 width=4) (actual time=0.050..0.111 rows=33 loops=1)
                     ->  Index Only Scan using log_anc_desc_idx on log_hierarchies log_hierarchies_1  (cost=0.57..4396.98 rows=2420 width=4) (actual time=0.048..0.080 rows=33 loops=1)
                           Index Cond: (ancestor_id = 1022533)
                           Heap Fetches: 33
         ->  Index Scan using log_desc_idx on log_hierarchies  (cost=0.57..483.82 rows=11962 width=10) (actual time=0.024..0.306 rows=17 loops=33)
               Index Cond: (descendant_id = "ANY_subquery".descendant_id)
 Planning time: 0.290 ms
 Execution time: 11.246 ms
(11 rows)
```

This commit fix issue with OR in condition. If we have OR we can't use indexes -> fullscan.

We can run 2 fast queries, because we run them in transaction.