### PR TITLE
Get extra attibutes from the model for the digraph export

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,11 @@ Then, in a shell, ```dot -Tpng example.dot > example.png```, which produces:
 
 If you want to customize the label value, override the ```#to_digraph_label``` instance method in your model.
 
+If you want to add other [dot file attributes](http://www.graphviz.org/doc/info/attrs.html) you can override
+```#to_digraph_extra_attributes``` to get them into your nodes. In this way it is possible to create a
+SVG file with clickable nodes by adding the `URL` and `target` attributes. The method should
+return a Hash with keys and values and closure_tree will construct the correct attribute string out of them.
+
 Just for kicks, this is the test tree I used for proving that preordered tree traversal was correct:
 
 ![Preordered test tree](https://raw.github.com/mceachen/closure_tree/master/img/preorder.png)

--- a/lib/closure_tree/digraphs.rb
+++ b/lib/closure_tree/digraphs.rb
@@ -21,10 +21,19 @@ module ClosureTree
           if id_to_instance.key? ea._ct_parent_id
             output << "  \"#{ea._ct_parent_id}\" -> \"#{ea._ct_id}\"\n"
           end
-          output << "  \"#{ea._ct_id}\" [label=\"#{ea.to_digraph_label}\"]\n"
+          output << "  \"#{ea._ct_id}\" [label=\"#{ea.to_digraph_label}\" #{extra_attributes(ea)}]\n"
         end
         output << "}\n"
         output.string
+      end
+
+      def extra_attributes ea
+        if ea.respond_to? :to_digraph_extra_attributes
+          attributes_hash = ea.to_digraph_extra_attributes
+          attributes_hash.map { |key, value| "#{key.to_s}=\"#{value.to_s}\"" }.join(" ")
+        else
+          ""
+        end
       end
     end
   end


### PR DESCRIPTION
We use this gem to generate a dot file that we pick up with [ruby_graphviz](https://github.com/glejeune/Ruby-Graphviz) to show in a browser. Now we wanted to make nodes clickable and found out that the fastest path was to get more information into the dot file. In our case the `URL` and `target` attributes but the proposed solution can be used for any attribute.