### PR TITLE
fix validation on parent for Rails 5

### DIFF
--- a/lib/closure_tree/model.rb
+++ b/lib/closure_tree/model.rb
@@ -9,7 +9,8 @@ module ClosureTree
                  class_name: _ct.model_class.to_s,
                  foreign_key: _ct.parent_column_name,
                  inverse_of: :children,
-                 touch: _ct.options[:touch]
+                 touch: _ct.options[:touch],
+                 required: false
 
       order_by_generations = "#{_ct.quoted_hierarchy_table_name}.generations asc"
 


### PR DESCRIPTION
This ( temporarily ) fixes the issue for Rails 5. I'm running out of time and I don't have time to test for Rails 4 right now, but will do tomorrow. I will also find a way to support both in case this fails on Rails 4 ( maybe because `required` is an unknown key for belongs_to on Rails 4 )