### PR TITLE
Enhance compatibility for SqlServer 2008

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: ruby
 rvm:
   - 2.0
   - 2.2.3
+  - 2.3.0
   - jruby-head
 
 gemfile:

--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -39,7 +39,7 @@ module ClosureTree
           SELECT descendant_id
           FROM #{_ct.quoted_hierarchy_table_name}
           WHERE ancestor_id = #{_ct.quote(self.id)}
-          GROUP BY 1
+          GROUP BY descendant_id
           HAVING MAX(#{_ct.quoted_hierarchy_table_name}.generations) = #{generation_level.to_i}
         ) AS descendants ON (#{_ct.quoted_table_name}.#{_ct.base_class.primary_key} = descendants.descendant_id)
       SQL
@@ -74,7 +74,7 @@ module ClosureTree
           INNER JOIN (
             SELECT ancestor_id
             FROM #{_ct.quoted_hierarchy_table_name}
-            GROUP BY 1
+            GROUP BY ancestor_id
             HAVING MAX(#{_ct.quoted_hierarchy_table_name}.generations) = 0
           ) AS leaves ON (#{_ct.quoted_table_name}.#{primary_key} = leaves.ancestor_id)
         SQL
@@ -100,7 +100,7 @@ module ClosureTree
           INNER JOIN (
             SELECT ancestor_id, descendant_id
             FROM #{_ct.quoted_hierarchy_table_name}
-            GROUP BY 1, 2
+            GROUP BY ancestor_id, descendant_id
             HAVING MAX(generations) = #{generation_level.to_i}
           ) AS descendants ON (
             #{_ct.quoted_table_name}.#{primary_key} = descendants.descendant_id

--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -72,7 +72,7 @@ module ClosureTree
           JOIN (
             SELECT descendant_id, max(generations) AS max_depth
             FROM #{_ct.quoted_hierarchy_table_name}
-            GROUP BY 1
+            GROUP BY descendant_id
           ) AS depths ON depths.descendant_id = anc.#{_ct.quoted_id_column_name}
         SQL
         joins(join_sql)


### PR DESCRIPTION
The code contains several statements like "GROUP BY 1". This is not supported in MS SQL, but can easily rewritten to "GROUP BY ascendent_id", which works for all SQL implementations.