### PR TITLE
adds ActiveRecord >= 5.0.0.beta1 support for tree roots; fixes #195

### DIFF
--- a/lib/closure_tree/model.rb
+++ b/lib/closure_tree/model.rb
@@ -5,11 +5,13 @@ module ClosureTree
     extend ActiveSupport::Concern
 
     included do
-      belongs_to :parent,
-                 class_name: _ct.model_class.to_s,
-                 foreign_key: _ct.parent_column_name,
-                 inverse_of: :children,
-                 touch: _ct.options[:touch]
+
+      belongs_to :parent, nil, *_ct.belongs_to_with_optional_option(
+        class_name: _ct.model_class.to_s,
+        foreign_key: _ct.parent_column_name,
+        inverse_of: :children,
+        touch: _ct.options[:touch],
+        optional: true)
 
       order_by_generations = "#{_ct.quoted_hierarchy_table_name}.generations asc"
 

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -76,6 +76,10 @@ module ClosureTree
       end
     end
 
+    def belongs_to_with_optional_option(opts)
+      [ActiveRecord::VERSION::MAJOR < 5 ? opts.except(:optional) : opts]
+    end
+
     # lambda-ize the order, but don't apply the default order_option
     def has_many_without_order_option(opts)
         [lambda { order(opts[:order]) }, opts.except(:order)]


### PR DESCRIPTION
ActiveRecord 5 now defaults a `belongs_to` relation to be required, which does not work for a tree structure where the root will not have a `:parent`.

To manage this change in default behavior, AR 5 adds an `optional: true` key, which I have added here. However, this key is not allowed in versions prior to AR 5 and will raise an exception if provided, so its inclusion requires a conditional check to maintain backwards compatibility.

Per earlier comments in #196, I've added a method to the `support.rb` file that checks the version and strips the `optional` key if necessary.  I've tried to be consistent with the naming of the support method, but am happy to make changes if we'd rather do something different.  (Not sure if the name is acceptable, or if you like the use of a ternary operator.)

This will maintain backwards compatibility with AR 4 without changing any functionality.
