### PR TITLE
Fixed Rails 5 Active Record method name collision.

### DIFF
--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -47,12 +47,12 @@ module ClosureTree
     end
 
     def without_self(scope)
-      scope.without(self)
+      scope.without_instance(self)
     end
 
     module ClassMethods
 
-      def without(instance)
+      def without_instance(instance)
         if instance.new_record?
           all
         else


### PR DESCRIPTION
Rails 5 introduces a #without() method and it is used instead of the one defined in the ClassMethods module. This caused #ancestors() to return an Array rather than a relation object.