### PR TITLE
Check db connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 6.0.1
+
+* Add `database_less` configuration to not raise an error during build step when
+  database is unavailable which is a common case in some PaaS like
+  (Heroku, Catalyze, ..., etc).
+
 ### 6.0.0
 
 * [Andrew Kumanyaev](https://github.com/zzet) *dramatically* improved mutation performance on large trees. 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Note that closure_tree only supports ActiveRecord 4.1 and later, and has test co
 
     If you're starting from scratch you don't need to call `rebuild!`.
 
+NOTE: Run `rails g closure_tree:config` to create an initializer with extra
+      configurations. (Optional)
+
 ## Warning
 
 As stated above, using multiple hierarchy gems (like `ancestry` or `nested set`) on the same model 

--- a/lib/closure_tree.rb
+++ b/lib/closure_tree.rb
@@ -12,6 +12,15 @@ module ClosureTree
   autoload :Digraphs
   autoload :DeterministicOrdering
   autoload :NumericDeterministicOrdering
+  autoload :Configuration
+
+  def self.configure
+    yield configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
 end
 
 ActiveSupport.on_load :active_record do

--- a/lib/closure_tree/configuration.rb
+++ b/lib/closure_tree/configuration.rb
@@ -1,4 +1,9 @@
 module ClosureTree
   class Configuration # :nodoc:
+    attr_accessor :database_less
+
+    def initialize
+      @database_less = false
+    end
   end
 end

--- a/lib/closure_tree/configuration.rb
+++ b/lib/closure_tree/configuration.rb
@@ -1,0 +1,4 @@
+module ClosureTree
+  class Configuration # :nodoc:
+  end
+end

--- a/lib/closure_tree/has_closure_tree.rb
+++ b/lib/closure_tree/has_closure_tree.rb
@@ -30,8 +30,7 @@ module ClosureTree
       include ClosureTree::DeterministicOrdering if _ct.order_option?
       include ClosureTree::NumericDeterministicOrdering if _ct.order_is_numeric?
     rescue StandardError => e
-      # Support Heroku's database-less assets:precompile pre-deploy step:
-      raise e unless ENV['DATABASE_URL'].to_s.include?('//user:pass@127.0.0.1/')
+      raise e unless ClosureTree.configuration.database_less
     end
 
     alias_method :acts_as_tree, :has_closure_tree

--- a/lib/generators/closure_tree/config_generator.rb
+++ b/lib/generators/closure_tree/config_generator.rb
@@ -1,0 +1,12 @@
+module ClosureTree
+  module Generators # :nodoc:
+    class ConfigGenerator < Rails::Generators::Base # :nodoc:
+      source_root File.expand_path('../templates', __FILE__)
+      desc 'Install closure tree config.'
+
+      def config
+        template 'config.rb', 'config/initializers/closure_tree_config.rb'
+      end
+    end
+  end
+end

--- a/lib/generators/closure_tree/templates/config.rb
+++ b/lib/generators/closure_tree/templates/config.rb
@@ -1,0 +1,2 @@
+ClosureTree.configure do |config|
+end

--- a/lib/generators/closure_tree/templates/config.rb
+++ b/lib/generators/closure_tree/templates/config.rb
@@ -1,2 +1,5 @@
 ClosureTree.configure do |config|
+  # Some PaaS like Heroku don't have available the db in some build steps like
+  # assets:precompile, this is skipped when this value is true, default = false
+  # config.database_less = true
 end


### PR DESCRIPTION
Class `has_closure_tree.rb` was validating only the Heroku config unfortunately other PaaS like Catalyze does not have the same configuration, after this PR will be posible create a config file and skip the error when app is deployed for one of those platforms.