### PR TITLE
Remove unused instance variable

### DIFF
--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -36,7 +36,7 @@ module ClosureTree
 
     def _ct_after_save
       if changes[_ct.parent_column_name] || @was_new_record
-        rebuild! unless @_ct_skip_hierarchy_maintenance
+        rebuild!
       end
       if changes[_ct.parent_column_name] && !@was_new_record
         # Resetting the ancestral collections addresses


### PR DESCRIPTION
This instance variable was introduced [here](https://github.com/mceachen/closure_tree/commit/31de226bc774ee37a9309fdcf84d6417cb5e87f6) but doesn't seem to be used anymore. 