### PR TITLE
Make with_ancestor work with ActiveRecord_AssociationRelation param

### DIFF
--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -82,7 +82,7 @@ module ClosureTree
       end
 
       def with_ancestor(*ancestors)
-        ancestor_ids = ancestors.map { |ea| ea.is_a?(ActiveRecord::Base) ? ea._ct_id : ea }
+        ancestor_ids = ancestors.map { |ea| ea.is_a?(ActiveRecord::Base) ? ea._ct_id : ea.to_a }
         scope = ancestor_ids.blank? ? all : joins(:ancestor_hierarchies).
           where("#{_ct.hierarchy_table_name}.ancestor_id" => ancestor_ids).
           where("#{_ct.hierarchy_table_name}.generations > 0").

--- a/spec/tag_examples.rb
+++ b/spec/tag_examples.rb
@@ -379,6 +379,11 @@ shared_examples_for Tag do
         expect(tag_class.where(:name => 'C').to_a).to match_array([a1c, a2c])
         expect(tag_class.with_ancestor(a1c.parent.parent).where(:name => 'C').to_a).to eq([a1c])
       end
+      it 'works with ActiveRecord_AssociationRelation param' do
+        b = tag_class.find_or_create_by_path %w(A B)
+        a = b.parent
+        expect(tag_class.with_ancestor(b.ancestors)).not_to be_empty
+      end
     end
 
     context 'paths' do


### PR DESCRIPTION
Hi @mceachen, it is my use case :
I use `with_ancestor` with `ancestors` of a `Category`'s instance
just like that : `Category.with_ancestor(c.ancestors)` but it always return empty array
I found that it because use `Category::ActiveRecord_AssociationRelation` as param go wrong,
but `Category.with_ancestor(c.ancestors.to_a)` works well
So I make some change to make `with_ancestor` can accept this type of param
