### PR TITLE
Use batch processing methods in Hierarchy Maintenance when looping through database records

### DIFF
--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -53,7 +53,7 @@ module ClosureTree
       _ct.with_advisory_lock do
         delete_hierarchy_references
         if _ct.options[:dependent] == :nullify
-          self.class.find(self.id).children.each { |c| c.rebuild! }
+          self.class.find(self.id).children.find_each { |c| c.rebuild! }
         end
       end
       true # don't prevent destruction
@@ -79,7 +79,7 @@ module ClosureTree
           _ct_reorder_siblings if !called_by_rebuild
         end
 
-        children.each { |c| c.rebuild!(true) }
+        children.find_each { |c| c.rebuild!(true) }
 
         _ct_reorder_children if _ct.order_is_numeric? && children.present?
       end
@@ -110,7 +110,7 @@ module ClosureTree
       def rebuild!
         _ct.with_advisory_lock do
           hierarchy_class.delete_all # not destroy_all -- we just want a simple truncate.
-          roots.each { |n| n.send(:rebuild!) } # roots just uses the parent_id column, so this is safe.
+          roots.find_each { |n| n.send(:rebuild!) } # roots just uses the parent_id column, so this is safe.
         end
         nil
       end


### PR DESCRIPTION
## The problem

I'm migrating from system where my model already has a`parent_id` column so following the documentation when I tried running `Tag.rebuild!` to have my `tag_hierarchies` table truncated and rebuilt I got an error. 

Initially this resulted in `Java::JavaLang::OutOfMemoryError: GC overhead limit exceeded` (with the default JVM heap size of 512MB). 

## A solution
Expanding the memory via `JRUBY_OPTS=-J-Xmx32G` did the trick and `rebuild!` passed successfully but with ever expanding heap.

You can take a look of this `jvisualvm` screenshots made before the proposed change:

<img width="1438" alt="local-32g-monitored-index" src="https://cloud.githubusercontent.com/assets/705812/24052265/8bfef13e-0b3d-11e7-9135-20ba3f990d70.png">

and after:

<img width="1442" alt="local-32g-monitored-index-limit" src="https://cloud.githubusercontent.com/assets/705812/24052306/b3dc53f4-0b3d-11e7-9a03-e6127673b63b.png">

This even allows my 512MB setup to succeed:

<img width="1439" alt="local-512mb-default-index-limit" src="https://cloud.githubusercontent.com/assets/705812/24052328/c9f0b194-0b3d-11e7-92f2-18c6dc4cacc3.png">

## Context
- My test database is populated with ~49k nodes that results in ~240k rows hierarchy and is roughly 10 times smaller than production.
- The setup:
  - macOS Sierra 10.12.3, 3.5 GHz Intel Core i5, 8 GB 1600 MHz DDR3
  - jruby-9.1.2.0
  - PostgreSQL 9.6.2

