### PR TITLE
Fix ActiveSupport 5.1 deprecation warnings

### DIFF
--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -35,10 +35,13 @@ module ClosureTree
     end
 
     def _ct_after_save
-      if changes[_ct.parent_column_name] || @was_new_record
+      as_5_1 = ActiveSupport.version >= Gem::Version.new('5.1.0')
+      changes_method = as_5_1 ? :saved_changes : :changes
+
+      if public_send(changes_method)[_ct.parent_column_name] || @was_new_record
         rebuild!
       end
-      if changes[_ct.parent_column_name] && !@was_new_record
+      if public_send(changes_method)[_ct.parent_column_name] && !@was_new_record
         # Resetting the ancestral collections addresses
         # https://github.com/mceachen/closure_tree/issues/68
         ancestor_hierarchies.reload

--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -10,8 +10,13 @@ module ClosureTree
     end
 
     def _ct_reorder_prior_siblings_if_parent_changed
-      if attribute_changed?(_ct.parent_column_name) && !@was_new_record
-        was_parent_id = attribute_was(_ct.parent_column_name)
+      as_5_1 = ActiveSupport.version >= Gem::Version.new('5.1.0')
+      change_method = as_5_1 ? :saved_change_to_attribute? : :attribute_changed?
+
+      if public_send(change_method, _ct.parent_column_name) && !@was_new_record
+        attribute_method = as_5_1 ? :attribute_before_last_save : :attribute_was
+
+        was_parent_id = public_send(attribute_method, _ct.parent_column_name)
         _ct.reorder_with_parent_id(was_parent_id)
       end
     end


### PR DESCRIPTION
Notably, there are still 4 test failures on ActiveRecord-edge, having to do with the "chained activerecord association subroot" tests. Debugging those is beyond my level of acquaintance with the code base. But the deprecation warnings surrounding `attribute_changed?`, `attribute_was`, and `changes` have all been silenced here.