### PR TITLE
Return database connection into pool after configuration

### DIFF
--- a/lib/closure_tree/has_closure_tree.rb
+++ b/lib/closure_tree/has_closure_tree.rb
@@ -29,6 +29,8 @@ module ClosureTree
 
       include ClosureTree::DeterministicOrdering if _ct.order_option?
       include ClosureTree::NumericDeterministicOrdering if _ct.order_is_numeric?
+
+      connection_pool.release_connection
     rescue StandardError => e
       raise e unless ClosureTree.configuration.database_less
     end

--- a/lib/closure_tree/has_closure_tree_root.rb
+++ b/lib/closure_tree/has_closure_tree_root.rb
@@ -81,6 +81,8 @@ module ClosureTree
 
         @closure_tree_roots[assoc_name][assoc_map] = root
       end
+
+      connection_pool.release_connection
     end
   end
 end

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'Configuration' do
+  it 'returns connection to the pool after has_closure_tree setup' do
+    class TypeDuplicate < ActiveRecord::Base
+      self.table_name = "namespace_type#{table_name_suffix}"
+      has_closure_tree
+    end
+    expect(ActiveRecord::Base.connection_pool.active_connection?).to be_falsey # +false+ in AR 4, +nil+ in AR 5
+  end
+
+  it 'returns connection to the pool after has_closure_tree setup with order' do
+    class MetalDuplicate < ActiveRecord::Base
+      self.table_name = "#{table_name_prefix}metal#{table_name_suffix}"
+      has_closure_tree order: 'sort_order', name_column: 'value'
+    end
+    expect(ActiveRecord::Base.connection_pool.active_connection?).to be_falsey
+  end
+
+  it 'returns connection to the pool after has_closure_tree_root setup' do
+    class GroupDuplicate < ActiveRecord::Base
+      self.table_name = "#{table_name_prefix}group#{table_name_suffix}"
+      has_closure_tree_root :root_user
+    end
+    expect(ActiveRecord::Base.connection_pool.active_connection?).to be_falsey
+  end
+end


### PR DESCRIPTION
When application code being loaded `has_closure_tree` method will get database connection implicitly and will not return it into the pool.

In some circumstances this connection will not be available for request processing at runtime anymore.

In my case I've launched Rails app in Puma application server with one thread and with DB pool size set to one and I was unable to do any requests as only available connection was taken by closure_tree gem (I always get `ActiveRecord::ConnectionTimeoutError`)