### PR TITLE
speed up rebuild in postgres

### DIFF
--- a/lib/closure_tree/numeric_order_support.rb
+++ b/lib/closure_tree/numeric_order_support.rb
@@ -44,7 +44,8 @@ module ClosureTree
             FROM #{quoted_table_name}
             WHERE #{where_eq(parent_column_name, parent_id)} #{min_where}
           ) AS t
-          WHERE #{quoted_table_name}.#{quoted_id_column_name} = t.id
+          WHERE #{quoted_table_name}.#{quoted_id_column_name} = t.id and
+                #{quoted_table_name}.#{quoted_order_column(false)} is distinct from t.seq + #{minimum_sort_order_value.to_i - 1}
         SQL
       end
 


### PR DESCRIPTION
The change simply exempts all records that will not change in the update.

Since `reorder_with_parent_id` is called a lot for rebuild! this leads to a huge performance boost for our data.
(many small trees, we have some 10k records and 4k top level elements)

Great tests by the way. My first solution got the check wrong with respect to null values (`!=` instead of `is distinct from`)...

I ran the tests for postgres only and one rails version, but the nature of the change should allow that.
